### PR TITLE
Added `query_string` parameter to cache

### DIFF
--- a/aqandu/api_routes.py
+++ b/aqandu/api_routes.py
@@ -88,7 +88,7 @@ def rawDataFrom():
 
 
 @app.route("/api/liveSensors", methods=["GET"])
-@cache.cached(timeout=59)
+@cache.cached(timeout=59, query_string=True)
 def liveSensors():
     # Get the arguments from the query string
     sensor_source = request.args.get('sensorSource')


### PR DESCRIPTION
Added `query_string` parameter to cache on `/liveSensors` because query parameters were not previously considered in caching. So if I set `sensorSource=DAQ` then the url will only use that for that next minute, making it look like we're missing all the sensors.